### PR TITLE
Updating version from 0.2 -> 0.2.1

### DIFF
--- a/rustls-symcrypt/Cargo.lock
+++ b/rustls-symcrypt/Cargo.lock
@@ -290,7 +290,7 @@ checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-symcrypt"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "der",
  "env_logger",
@@ -360,7 +360,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symcrypt"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "lazy_static",
  "libc",

--- a/rustls-symcrypt/Cargo.toml
+++ b/rustls-symcrypt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustls-symcrypt"
 authors = ["Microsoft"]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "Apache-2.0 OR ISC OR MIT"
 description = "Implementation of rustls crypto provider model for SymCrypt"
@@ -14,7 +14,7 @@ readme = "README.md"
 [dependencies]
 # Disable aws_ls_rc since it is not needed and increases build time.
 rustls = { version = "0.23.0", features = ["tls12", "std"], default-features = false }
-symcrypt = { path = "../../rust-symcrypt/rust-symcrypt", version = "0.5.0" }
+symcrypt = { path = "../../rust-symcrypt/rust-symcrypt", version = "0.5.1" }
 pkcs1 = { version = "0.7.5", features = ["alloc"], default-features = false }
 rustls-webpki = {version = "0.102.2", features = ["std"], default-features = false}
 pkcs8 = "0.10"

--- a/rustls-symcrypt/README.md
+++ b/rustls-symcrypt/README.md
@@ -78,9 +78,9 @@ Add `rustls-symcrypt` to your `Cargo.toml`:
 [dependencies]
 # Disabling aws-lc as it slows down build times and is not needed.
 rustls = { version = "0.23.0", features = ["tls12", "std"], default-features = false }
-rustls_symcrypt = "0.2.0"
+rustls_symcrypt = "0.2.1"
 # To enable the chacha feature:
-# rustls_symcrypt = {version = "0.2.0", features = ["chacha"]}
+# rustls_symcrypt = {version = "0.2.1", features = ["chacha"]}
 ```
 
 ### Default Configuration


### PR DESCRIPTION
There was a dangling pointer found in rust-symcrypt's RSA code. 

Updating the version number from `0.2` -> `0.2.1`